### PR TITLE
Update mobile-topic-floating-reply.js.es6

### DIFF
--- a/javascripts/discourse/connectors/before-topic-progress/mobile-topic-floating-reply.js.es6
+++ b/javascripts/discourse/connectors/before-topic-progress/mobile-topic-floating-reply.js.es6
@@ -2,7 +2,7 @@ export default {
   actions: {
     floatingReply(params) {
       //hack to exploit the only available action supported by plugin connector
-      this.sendAction('jumpToPost', params)
+      this.jumpToPost(params);
     }
   }
 }


### PR DESCRIPTION
This fix replaces this.sendAction('jumpToPost', params) with this.jumpToPost(params) inside the floatingReply action. This calls the 'jumpToPost' action directly